### PR TITLE
[FEATURE] Add explicit 'enabled' option to site configuration

### DIFF
--- a/Classes/Middleware/Oauth2Configuration.php
+++ b/Classes/Middleware/Oauth2Configuration.php
@@ -34,7 +34,7 @@ class Oauth2Configuration implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $siteConfiguration = $request->getAttribute('site')->getConfiguration()['oauth2'] ?? false;
-        if ($siteConfiguration === false) {
+        if ($siteConfiguration === false || !($siteConfiguration['enabled'] ?? true)) {
             return $handler->handle($request);
         }
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ oauth2: []
 ```
 
 For the authorization code grant you must create a frontend login and a consent page.<br>
-This extensions provides a Typoscript setup with a basic design.
+This extension provides a Typoscript setup with a basic design.
 
 Create a sysfolder and add a client record.
 
@@ -37,16 +37,19 @@ Create a sysfolder and add a client record.
 
 ## Endpoints
 
-Endpoint | Description
---- | ---
-/oauth2/authorize | GET = Start authorization, POST = Accept, DELETE = Deny
-/oauth2/token | Issues token
-/oauth2/revoke | Revokes an access token
+| Endpoint          | Description                                             |
+|-------------------|---------------------------------------------------------|
+| /oauth2/authorize | GET = Start authorization, POST = Accept, DELETE = Deny |
+| /oauth2/token     | Issues token                                            |
+| /oauth2/revoke    | Revokes an access token                                 |
 
 ## Configuration
 
 ```yaml
 oauth2:
+  # Optional. Defaults to 'true'
+  enabled: true
+
   # Path to private key
   # Type: string
   privateKey: 'EXT:oauth2_server/Resources/Private/Keys/private.key'

--- a/Tests/Fixtures/config/sites/root/config.yaml
+++ b/Tests/Fixtures/config/sites/root/config.yaml
@@ -17,4 +17,5 @@ languages:
 rootPageId: 1
 routes: {  }
 websiteTitle: 'Test Oauth2 Server'
-oauth2: []
+oauth2:
+  enabled: true


### PR DESCRIPTION
The option is optional and defaults to `true`.

This allows site maintainers to disable the extension by overriding the configuration.