### PR TITLE
[TASK] Allow key-files in any path

### DIFF
--- a/Classes/Domain/Factory/AuthorizationServerFactory.php
+++ b/Classes/Domain/Factory/AuthorizationServerFactory.php
@@ -45,7 +45,7 @@ class AuthorizationServerFactory implements AuthorizationServerFactoryInterface
             $this->getClientRepository($configuration),
             $this->getAccessTokenRepository($configuration),
             $this->getScopeRepository($configuration),
-            GeneralUtility::getFileAbsFileName($configuration->getPrivateKey()),
+            $configuration->getPrivateKey(),
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'],
             $this->getResponseType($configuration)
         );

--- a/Classes/Domain/Factory/ResourceServerFactory.php
+++ b/Classes/Domain/Factory/ResourceServerFactory.php
@@ -29,7 +29,7 @@ class ResourceServerFactory implements ResourceServerFactoryInterface
         $server = GeneralUtility::makeInstance(
             ResourceServer::class,
             GeneralUtility::makeInstance(AccessTokenRepositoryInterface::class),
-            GeneralUtility::getFileAbsFileName($configuration->getPublicKey())
+            $configuration->getPublicKey()
         );
 
         return $server;


### PR DESCRIPTION
Drop the usage of `GeneralUtility::getFileAbsFileName` for the key file locations.
This limits the file locations to the project, but it is legitimate (and safer) to store the files
somewhere else on the server,