### PR TITLE
[FEATURE] Always process authorization header

### DIFF
--- a/Classes/Middleware/Oauth2Authenticator.php
+++ b/Classes/Middleware/Oauth2Authenticator.php
@@ -40,7 +40,7 @@ class Oauth2Authenticator implements MiddlewareInterface
         }
 
         $authorization = $route->getOptions()['authorization'] ?? true;
-        if ($authorization === false) {
+        if ($authorization === false && !$request->hasHeader('authorization')) {
             return $handler->handle($request);
         }
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ oauth2:
       # Type: string
       path: /rest/.*
 
+      # Defines whether authorization is required
+      # Note: A given authorization header is still processed even if this is disabled.
+      #       This is great for APIs with optional authentication
+      # Type: boolean
+      authorization: true
+
       # Resource methods (optional)
       # Type: string|array
       methods: POST|GET


### PR DESCRIPTION
If authorization is not required for a route
still process a possibly present authorization header.

This allows for routes where authentication is optional.