### PR TITLE
[BUGFIX] Ensure FE context is asserted by ConfigurationManager

### DIFF
--- a/Classes/Middleware/Oauth2Authenticator.php
+++ b/Classes/Middleware/Oauth2Authenticator.php
@@ -57,6 +57,9 @@ class Oauth2Authenticator implements MiddlewareInterface
         // $resourceServerFactory = GeneralUtility::makeInstance(ResourceServerFactory::class);
         // $resourceServer = $resourceServerFactory($configuration);
 
+        // this is required so that Extbase ConfigurationManager deems this as FE context
+        // the next line causes the ConfigurationManager to get initialized (due to DI chain)
+        $GLOBALS['TYPO3_REQUEST'] = $request;
         $resourceServer = GeneralUtility::makeInstance(ResourceServer::class);
 
         try {


### PR DESCRIPTION
By setting the TYPO3_REQUEST early,
we ensure the Extbase ConfigurationManager is
initialized in FE context.

Fixes #20