### PR TITLE
[BUGFIX] Initialize Response object correctly for revokeAccessToken

### DIFF
--- a/Classes/Controller/RevokeController.php
+++ b/Classes/Controller/RevokeController.php
@@ -38,6 +38,6 @@ class RevokeController
     {
         $tokenId = $request->getAttribute('oauth_access_token_id');
         $this->accessTokenRepository->revokeAccessToken($tokenId);
-        return new Response('', 204);
+        return (new Response())->withStatus(204);
     }
 }


### PR DESCRIPTION
The first parameter must not be empty.
Use named parameters to keep the default.