### PR TITLE
[TASK] Add PHP 8.4 and 8.5 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,11 @@ jobs:
           - { PHP: '8.1', TYPO3_VERSION: ^12.4 }
           - { PHP: '8.2', TYPO3_VERSION: ^12.4 }
           - { PHP: '8.3', TYPO3_VERSION: ^12.4 }
-          - { PHP: '8.2', TYPO3_VERSION: ^13.1 }
-          - { PHP: '8.3', TYPO3_VERSION: ^13.1 }
+          - { PHP: '8.4', TYPO3_VERSION: ^12.4 }
+          - { PHP: '8.2', TYPO3_VERSION: ^13.4 }
+          - { PHP: '8.3', TYPO3_VERSION: ^13.4 }
+          - { PHP: '8.4', TYPO3_VERSION: ^13.4 }
+          - { PHP: '8.5', TYPO3_VERSION: ^13.4 }
 
     env: ${{ matrix.env }}
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -5,7 +5,7 @@ cd "$THIS_SCRIPT_DIR" || exit 1
 cd ../Docker || exit 1
 
 export PHP=${PHP:-8.1}
-export DOCKER_PHP_IMAGE=`echo "typo3/core-testing-php${PHP}" | sed -e 's/\.//'`
+export DOCKER_PHP_IMAGE="ghcr.io/typo3/core-testing-php`echo ${PHP} | sed -e 's/\.//'`"
 export ROOT_DIR=`readlink -f ${PWD}/../../`
 export HOST_UID=`id -u`
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"require": {
-		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+		"php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"league/oauth2-server": "^9.0",
 		"symfony/psr-http-message-bridge": "^6.4",
 		"typo3/cms-core": "^12.4 || ^13.4"

--- a/rector.php
+++ b/rector.php
@@ -38,8 +38,8 @@ return RectorConfig::configure()
         ConvertImplicitVariablesToExplicitGlobalsRector::class,
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.3.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-13.1.99',
+        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.5.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-13.4.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     // If you use withImportNames(), you should consider excluding some TYPO3 files.


### PR DESCRIPTION
The code is already compatible, but Metadata-Files / Tests are not

* composer.json: Allow PHP 8.4 and 8.5
* runTests.sh: see https://github.com/TYPO3/typo3/blob/main/Build/Scripts/runTests.sh#L957
* ci.yml: Extend matrix
* rector.php: Update rector constraints